### PR TITLE
Dockerfile ARGs to make it easier to use latest IPEX-LLM Ollama Portable Zip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=america/los_angeles
+ARG IPEXLLM_PORTABLE_ZIP_FILENAME=ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz
 
 # Base packages
 RUN apt update && \
@@ -24,8 +25,8 @@ RUN mkdir -p /tmp/gpu && \
 
 # Install Ollama Portable Zip 
 RUN cd / && \
-  wget https://github.com/mattcurf/ollama-intel-gpu/releases/download/v0.0.1/ollama-0.5.4-ipex-llm-2.2.0b20250220-ubuntu.tgz && \
-  tar xvf ollama-0.5.4-ipex-llm-2.2.0b20250220-ubuntu.tgz --strip-components=1 -C /
+  wget https://github.com/intel/ipex-llm/releases/download/v2.2.0-nightly/${IPEXLLM_PORTABLE_ZIP_FILENAME} && \
+  tar xvf ${IPEXLLM_PORTABLE_ZIP_FILENAME} --strip-components=1 -C /
 
 ENV OLLAMA_HOST=0.0.0.0:11434
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=america/los_angeles
-ARG IPEXLLM_PORTABLE_ZIP_FILENAME=ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz
+
 
 # Base packages
 RUN apt update && \
@@ -23,9 +23,12 @@ RUN mkdir -p /tmp/gpu && \
  dpkg -i *.deb && \
  rm *.deb
 
-# Install Ollama Portable Zip 
+# Install Ollama Portable Zip (with cached default)
+ARG IPEXLLM_RELEASE_REPO=mattcurf/ollama-intel-gpu
+ARG IPEXLLM_RELEASE_VERSON=v0.0.1 
+ARG IPEXLLM_PORTABLE_ZIP_FILENAME=ollama-0.5.4-ipex-llm-2.2.0b20250220-ubuntu.tgz
 RUN cd / && \
-  wget https://github.com/intel/ipex-llm/releases/download/v2.2.0-nightly/${IPEXLLM_PORTABLE_ZIP_FILENAME} && \
+  wget https://github.com/${IPEXLLM_RELEASE_REPO}/releases/download/${IPEXLLM_RELEASE_VERSON}/${IPEXLLM_PORTABLE_ZIP_FILENAME} && \
   tar xvf ${IPEXLLM_PORTABLE_ZIP_FILENAME} --strip-components=1 -C /
 
 ENV OLLAMA_HOST=0.0.0.0:11434

--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ $ docker compose up
 
 Then launch your web browser to http://localhost:3000 to launch the web ui.  Create a local OpenWeb UI credential, then click the settings icon in the top right of the screen, then select 'Models', then click 'Show', then download a model like 'llama3.1:8b-instruct-q8_0' for Intel ARC A770 16GB VRAM
 
+## Update to the latest IPEX-LLM Portable Zip Version
+
+To update to the latest portable zip version of IPEX-LLM's Ollama, update the compose file's `IPEXLLM_PORTABLE_ZIP_FILENAME` build argument to the latest `ollama-*.tgz` release from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly , then rebuild the image.
+
 # References
 * https://dgpu-docs.intel.com/driver/client/overview.html
 * https://github.com/intel/ipex-llm/blob/main/docs/mddocs/Quickstart/ollama_portablze_zip_quickstart.md

--- a/README.md
+++ b/README.md
@@ -31,7 +31,18 @@ Then launch your web browser to http://localhost:3000 to launch the web ui.  Cre
 
 ## Update to the latest IPEX-LLM Portable Zip Version
 
-To update to the latest portable zip version of IPEX-LLM's Ollama, update the compose file's `IPEXLLM_PORTABLE_ZIP_FILENAME` build argument to the latest `ollama-*.tgz` release from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly , then rebuild the image.
+To update to the latest portable zip version of IPEX-LLM's Ollama, update the compose file with the build arguments shown below, using the latest `ollama-*.tgz` release from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly , then rebuild the image.
+
+```yaml
+ollama-intel-gpu:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        IPEXLLM_RELEASE_REPO: intel/ipex-llm
+        IPEXLLM_RELEASE_VERSON: v2.2.0-nightly
+        IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz
+``` 
 
 # References
 * https://dgpu-docs.intel.com/driver/client/overview.html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
+        IPEXLLM_RELEASE_REPO: intel/ipex-llm
+        IPEXLLM_RELEASE_VERSON: v2.2.0-nightly
         IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz # update from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly
     container_name: ollama-intel-gpu
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,9 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        IPEXLLM_RELEASE_REPO: intel/ipex-llm
-        IPEXLLM_RELEASE_VERSON: v2.2.0-nightly
-        IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz # update from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly
+        IPEXLLM_RELEASE_REPO: mattcurf/ollama-intel-gpu
+        IPEXLLM_RELEASE_VERSON: v0.0.1
+        IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-0.5.4-ipex-llm-2.2.0b20250220-ubuntu.tgz
     container_name: ollama-intel-gpu
     restart: always
     devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.2.0b20250313-ubuntu.tgz # update from https://github.com/intel/ipex-llm/releases/tag/v2.2.0-nightly
     container_name: ollama-intel-gpu
     restart: always
     devices:


### PR DESCRIPTION
Resolves #46 (for Ollama only, not other hardcoded dependencies). 

Dockerfile ARGs to make it easier to user to update to the latest IPEX-LLM Ollama Portable Zip from upstream (updating at build time or via compose build arg). Defaults fall back to the cached version if no args provided at build time.