### PR TITLE
Updates for new Portable Zip repo location.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN mkdir -p /tmp/gpu && \
  rm *.deb
 
 # Install Ollama Portable Zip
-ARG IPEXLLM_RELEASE_REPO=intel/ipex-llm
+ARG IPEXLLM_RELEASE_REPO=ipex-llm/ipex-llm
 ARG IPEXLLM_RELEASE_VERSON=v2.2.0
 ARG IPEXLLM_PORTABLE_ZIP_FILENAME=ollama-ipex-llm-2.2.0-ubuntu.tgz
 RUN cd / && \

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then launch your web browser to http://localhost:3000 to launch the web ui.  Cre
 
 ## Update to the latest IPEX-LLM Portable Zip Version
 
-To update to the latest portable zip version of IPEX-LLM's Ollama, update the compose file with the build arguments shown below, using the latest `ollama-*.tgz` release from https://github.com/intel/ipex-llm/releases/tag/v2.3.0-nightly , then rebuild the image.
+To update to the latest portable zip version of IPEX-LLM's Ollama, update the compose file with the build arguments shown below, using the latest `ollama-*.tgz` release from https://github.com/ipex-llm/ipex-llm/releases/tag/v2.3.0-nightly , then rebuild the image.
 
 ```yaml
 ollama-intel-gpu:
@@ -39,7 +39,7 @@ ollama-intel-gpu:
       context: .
       dockerfile: Dockerfile
       args:
-        IPEXLLM_RELEASE_REPO: intel/ipex-llm
+        IPEXLLM_RELEASE_REPO: ipex-llm/ipex-llm
         IPEXLLM_RELEASE_VERSON: v2.3.0-nightly
         IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.3.0b20250415-ubuntu.tgz
 ``` 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        IPEXLLM_RELEASE_REPO: intel/ipex-llm
+        IPEXLLM_RELEASE_REPO: ipex-llm/ipex-llm
         IPEXLLM_RELEASE_VERSON: v2.2.0
         IPEXLLM_PORTABLE_ZIP_FILENAME: ollama-ipex-llm-2.2.0-ubuntu.tar.gz
     container_name: ollama-intel-gpu


### PR DESCRIPTION
Portable Zips moved from https://github.com/intel/ipex-llm/releases to https://github.com/ipex-llm/ipex-llm/releases